### PR TITLE
Fix incorrect readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ EXAMPLE
   # quick start with default config
   $ create-kaplay mygame
 
-  # if installed locally you don't need to use -- when passing options
+  # calling with options
   $ create-kaplay -t -s 4 -d -e burp mygame
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # create-kaplay
 
-a script to help you start a kaplay project in no time
+A script to help you start a kaplay project in no time
 
 ```
 USAGE
@@ -16,18 +16,15 @@ OPTIONS
   -h, --help             Print this message
   -t, --typescript       Use TypeScript
   -d, --desktop          Enable packaging for desktop release (uses tauri and requires rust to be installed)
-  -e, --example <name>   Start from a example listed on play.kaplayjs.com
-      --spaces <level>   Use spaces instead of tabs for generated files
+  -e, --example <name>   Start from an example listed on play.kaplayjs.com
+  -s  --spaces <level>   Use spaces instead of tabs for generated files
   -v, --version <label>  Use a specific kaplay version (default latest)
 
 EXAMPLE
 
   # quick start with default config
-  $ npm init kaplay mygame
-
-  # need to put all args after -- if using with npm init
-  $ npm init kaplay -- --typescript --example burp mygame
+  $ create-kaplay mygame
 
   # if installed locally you don't need to use -- when passing options
-  $ create-kaplay -t -s -d burp mygame
+  $ create-kaplay -t -s 4 -d -e burp mygame
 ```

--- a/create.js
+++ b/create.js
@@ -82,7 +82,7 @@ ${c(33, "EXAMPLE")}
   ${
     c(
         90,
-        "# if installed locally you don't need to use -- when passing options",
+        "# calling with options",
     )
 }
   $ create-kaplay -t -s 4 -d -e burp mygame


### PR DESCRIPTION
Readme commandline examples are outdated and wrong
The -s option is missing
Start sentence with capital letter