### PR TITLE
fix build script paths and outDir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,7 +380,7 @@ create(dir(dest, [
         ".gitignore",
         `
 node_modules/
-www/main.js
+www/
 dist/
 ${desktop ? "src-tauri/target/" : ""}
 	`,
@@ -412,10 +412,10 @@ will start a dev server at http://localhost:8000
 $ ${packageManager} run build
 \`\`\`
 
-will build your js files into \`www/main.js\`
+will build your js files into \`www/\`
 
 \`\`\`sh
-$ ${packageManager} run bundle
+$ ${packageManager} run zip
 \`\`\`
 
 will build your game and package into a .zip file, you can upload to your server or itch.io / newground etc.

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,7 @@ create(dir(dest, [
                 "dev": `vite`,
                 "preview": `vite preview`,
                 "zip":
-                    `${packageManager} run build && mkdir -p dist && zip -r dist/game.zip www -x \"**/.DS_Store\"`,
+                    `${packageManager} run build && mkdir -p dist && zip -r dist/game.zip dist -x \"**/.DS_Store\"`,
                 ...(ts
                     ? {
                         "check": "tsc",
@@ -380,7 +380,6 @@ create(dir(dest, [
         ".gitignore",
         `
 node_modules/
-www/
 dist/
 ${desktop ? "src-tauri/target/" : ""}
 	`,
@@ -391,7 +390,7 @@ ${desktop ? "src-tauri/target/" : ""}
 # Folder structure
 
 - \`src\` - source code for your kaplay project
-- \`www\` - distribution folder, contains your index.html, built js bundle and static assets
+- \`dist\` - distribution folder, contains your index.html, built js bundle and static assets
 ${
             desktop
                 ? "- `src-tauri` - tauri project folder, contains tauri config file, icons, rust source if you need native code"
@@ -412,7 +411,7 @@ will start a dev server at http://localhost:8000
 $ ${packageManager} run build
 \`\`\`
 
-will build your js files into \`www/\`
+will build your js files into \`dist/\`
 
 \`\`\`sh
 $ ${packageManager} run zip

--- a/src/template/vite.config.js
+++ b/src/template/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+    base: "./",
     build: {
         sourcemap: true,
         outDir: "www",

--- a/src/template/vite.config.js
+++ b/src/template/vite.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from "vite";
 export default defineConfig({
     build: {
         sourcemap: true,
+        outDir: "www",
     },
 });

--- a/src/template/vite.config.js
+++ b/src/template/vite.config.js
@@ -4,6 +4,5 @@ export default defineConfig({
     base: "./",
     build: {
         sourcemap: true,
-        outDir: "www",
     },
 });


### PR DESCRIPTION
Hello, I noticed a few things incorrect with the template when I tried building a zip.

I used the typescript template:

```
yarn create kaplay --typescript --spaces 2 mygame
```

It required these changes for a successful build:

- Add `outDir: "www"` to `template/vite.config.js` so that the Vite output goes to the `www/` directory, as expected by `yarn zip`.
- gitignore all of the `www/` folder, since the output of `yarn build` is actually `www/assets/index-<hash>.js`, not `www/main.js` (Vite performs this transformation automatically)
- Update documentation to match
- I believe `yarn bundle` in the README is a typo for `yarn zip`, but lmk if that's not correct

Here's the output of `yarn build` so you can see how Vite outputs `www/` by default:

```
$ yarn build
yarn run v1.22.22
warning package.json: No license field
$ vite build
vite v5.4.10 building for production...
✓ 5 modules transformed.
www/index.html                  0.19 kB │ gzip:  0.17 kB
www/assets/index-BNJisJFh.js  198.18 kB │ gzip: 73.23 kB
✓ built in 382ms
Done in 0.58s.
```