### PR TITLE
add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,6 +381,7 @@ create(dir(dest, [
         `
 node_modules/
 dist/
+.DS_Store
 ${desktop ? "src-tauri/target/" : ""}
 	`,
     ),


### PR DESCRIPTION
This PR adds the `.DS_Store` file to the `.gitignore` for both the main repo and any newly created game.  For Mac users, this file consistently shows up and is often gitignored so I believe it will be helpful to ignore it from the start.

Please let me know if you have any questions or concerns.

Thanks.